### PR TITLE
Added ability to show no text in the upper section of the screen

### DIFF
--- a/src/c/graphics.c
+++ b/src/c/graphics.c
@@ -56,12 +56,15 @@ void graphics_draw_upper_text(GContext *ctx, GRect bounds, bool is_animating, in
 		} else { // Otherwise, show step counts if Pebble Health, and string if not.
 			switch(display_text) {
 				case 0:
+					//No text
+					break;
+				case 1:
 					graphics_draw_text(ctx, greet_text, fonts_get_system_font(FONT_KEY), 
 											 GRect((bounds.size.w - greet_text_bounds.w) / 2, PBL_IF_RECT_ELSE(5, 15), greet_text_bounds.w, greet_text_bounds.h),
 											 GTextOverflowModeWordWrap, GTextAlignmentCenter, NULL);
 					break;
-				case 1:
 				case 2:
+				case 3:
 					graphics_draw_text(ctx, PBL_IF_HEALTH_ELSE(steps_buffer, greet_text), fonts_get_system_font(FONT_KEY), 
 											 GRect((bounds.size.w - greet_text_bounds.w) / 2, PBL_IF_RECT_ELSE(5, 15), greet_text_bounds.w, greet_text_bounds.h),
 											 GTextOverflowModeWordWrap, GTextAlignmentCenter, NULL);

--- a/src/c/settings.c
+++ b/src/c/settings.c
@@ -14,9 +14,9 @@ void settings_init() {
 	settings.vibrationType = 0;
 	settings.rememberDuration = false;
 	#if PBL_API_EXISTS(health_service_peek_current_value)
-		settings.displayText = 2;
+		settings.displayText = 3;
 	#else
-		settings.displayText = 1;
+		settings.displayText = 2;
 	#endif
 	settings.reminderHours = 4;
 	settings.reminderHoursStart = 8;

--- a/src/pkjs/config-de.js
+++ b/src/pkjs/config-de.js
@@ -106,16 +106,20 @@ module.exports = [
 				"description": "Legt fest, was im Hauptmenü oben angezeigt wird. Herzfrequenz setzt eine Uhr mit HR-Sensor voraus.",
 				"options": [
 					{
-						"label": "Begrüßung",
+						"label": "Nichts",
 						"value": "0"
+					},
+					{
+						"label": "Begrüßung",
+						"value": "1"
 					},
 					{ 
 						"label": "Schritte", 
-						"value": "1" 
+						"value": "2" 
 					},
 					{ 
 						"label": "Herzfrequenz",
-						"value": "2" 
+						"value": "3" 
 					}
 				]
 			},

--- a/src/pkjs/config-es.js
+++ b/src/pkjs/config-es.js
@@ -106,16 +106,20 @@ module.exports = [
 				"description": "Esto determina lo que está mostrado en el menu principal. NOTA: El ritmo cardiaco requiere un reloj con un monitor de ritmo cardiaco.",
 				"options": [
 					{
-						"label": "Saludo",
+						"label": "Nada",
 						"value": "0"
+					},
+					{
+						"label": "Saludo",
+						"value": "1"
 					},
 					{ 
 						"label": "Pasos hoy", 
-						"value": "1" 
+						"value": "2" 
 					},
 					{ 
 						"label": "Ritmo cardiaco",
-						"value": "2" 
+						"value": "3" 
 					}
 				]
 			},

--- a/src/pkjs/config-fr.js
+++ b/src/pkjs/config-fr.js
@@ -106,16 +106,20 @@ module.exports = [
 				"description": "Ceci détermine ce qui est montré en haut du menu principal. Montrer le rhythme cardiaque requiert une montre avec un moniteur cardiaque.",
 				"options": [
 					{
-						"label": "Salut",
+						"label": "Rien",
 						"value": "0"
+					},
+					{
+						"label": "Salut",
+						"value": "1"
 					},
 					{ 
 						"label": "Nombre de pas pris aujourd'hui", 
-						"value": "1" 
+						"value": "2" 
 					},
 					{ 
 						"label": "Rhythme cardiaque",
-						"value": "2" 
+						"value": "3" 
 					}
 				]
 			},

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -106,16 +106,20 @@ module.exports = [
 				"description": "This determines what the app shows at the top part of the main menu. Heart rate requires a watch with a heart rate monitor.",
 				"options": [
 					{
-						"label": "Greeting",
+						"label": "Nothing",
 						"value": "0"
+					},
+					{
+						"label": "Greeting",
+						"value": "1"
 					},
 					{ 
 						"label": "Steps today", 
-						"value": "1" 
+						"value": "2" 
 					},
 					{ 
 						"label": "Heart Rate",
-						"value": "2" 
+						"value": "3" 
 					}
 				]
 			},


### PR DESCRIPTION
There is now a configuration option (localized) to select “Nothing” to
display on the upper text portion of the splash screen of the
application